### PR TITLE
Fix a few errors. Clean up some naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Aave V3 Subgraph
+
+Just a simple implementation of aave v3 subgraph. Not fully complete.
+
+You can find it deployed here: https://thegraph.com/hosted-service/subgraph/davekaj/aave-v3
+
+You can find Aave contract addresses here https://docs.aave.com/developers/deployed-contracts/v3-testnet-addresses

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "PoolGraph",
+  "name": "aave-v3",
   "license": "UNLICENSED",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
-    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ PoolGraph",
-    "create-local": "graph create --node http://localhost:8020/ PoolGraph",
-    "remove-local": "graph remove --node http://localhost:8020/ PoolGraph",
-    "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 PoolGraph"
+    "deploy": "graph deploy --node https://api.thegraph.com/deploy/ davekaj/aave-v3"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.28.0",

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,4 @@
-type BorrowEvent @entity {
+type Borrow @entity {
 	id: ID!
 	market: Market!
 	borrower: Account!
@@ -10,7 +10,7 @@ type BorrowEvent @entity {
 	blockTime: Int!
 }
 
-type RepayEvent @entity {
+type Repay @entity {
 	id: ID!
 	amount: BigDecimal
 	market: Market!
@@ -21,7 +21,7 @@ type RepayEvent @entity {
 	useATokens: Boolean
 }
 
-type LiquidationEvent @entity {
+type Liquidation @entity {
 	"Transaction hash concatenated with log index"
 	id: ID!
 	asset: Asset
@@ -41,7 +41,7 @@ type LiquidationEvent @entity {
 	profit: BigDecimal
 }
 
-type DepositEvent @entity {
+type Deposit @entity {
 	id: ID!
 	asset: Asset
 	amount: BigDecimal
@@ -56,7 +56,7 @@ type DepositEvent @entity {
 	referralCode: Int
 }
 
-type WithdrawEvent @entity {
+type Withdraw @entity {
 	id: ID!
 	asset: Asset
 	amount: BigDecimal

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -1,31 +1,41 @@
 specVersion: 0.0.2
+description: Aave v3 subgraph
+repository: https://github.com/nmimran99/PoolGraph
 schema:
   file: ./schema.graphql
 dataSources:
-  - kind: ethereum
+  - kind: ethereum/contract
     name: Pool
     network: rinkeby
     source:
       address: "0x3561c45840e2681495ACCa3c50Ef4dAe330c94F8"
       abi: Pool
+      startBlock: 10054908
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - Upgraded
+        - Market
+        - Pool
       abis:
         - name: Pool
           file: ./abis/Pool.json
       eventHandlers:
+        - event: Supply(indexed address,address,indexed address,uint256,indexed uint16)
+          handler: handleDeposit
+        - event: Withdraw(indexed address,indexed address,indexed address,uint256)
+          handler: handleWithdraw
         - event: Borrow(indexed address,address,indexed address,uint256,uint8,uint256,indexed uint16)
           handler: handleBorrow
+        - event: Repay(indexed address,indexed address,indexed address,uint256,bool)
+          handler: handleRepay
+        - event: LiquidationCall(indexed address,indexed address,indexed address,uint256,uint256,address,bool)
+          handler: handleLiquidationCall
+        - event: SwapBorrowRateMode(indexed address,indexed address,uint8)
+          handler: handleSwapBorrowRateMode
         - event: IsolationModeTotalDebtUpdated(indexed address,uint256)
           handler: handleIsolationModeTotalDebtUpdated
         - event: RebalanceStableBorrowRate(indexed address,indexed address)
           handler: handleRebalanceStableBorrowRate
-        - event: Repay(indexed address,indexed address,indexed address,uint256,bool)
-          handler: handleRepay
-        - event: SwapBorrowRateMode(indexed address,indexed address,uint8)
-          handler: handleSwapBorrowRateMode
       file: ./src/mapping.ts


### PR DESCRIPTION
Good 1st implementation. I made a few small fixes which I will list below:
- updated .gitignore to ignore all three folders which are autogenerated files
- Renamed some things to be a bit more clear
- made it so Protocol id AAVE-V3 is derived from the AAVE-v3 address
- the main fix was adding Deposit/Supply and Withdraw to the subgraph.yaml, as they were not there before and thus were never being triggered.



Here are some further TODOs to work on:
- [ ] Add in prettier and eslint - similar to how this one was done https://github.com/squirtleDevs/subgraphs/tree/df5b4145312a830488f2c1e171c82b518ea3f6fe in `package.json`
- [ ] Track the Pool from the `PoolAddressesProviderRegistry`. [This event emits when a Pool is added to the aave protocol](https://github.com/aave/aave-v3-core/blob/c8722965501b182f6ab380db23e52983eb87e406/contracts/protocol/configuration/PoolAddressesProviderRegistry.sol#L48). Specifically the `provider` field.
   - [ ] You can then create the Pool as a template, instead of a data source
- [ ] Make all events use a graphql interface like so:
```graphql
interface UserTransaction {
  id: ID!
  pool: Pool!
  user: User!
  timestamp: Int!
}
```